### PR TITLE
update-ux

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import time
+
 import discord
 from discord import app_commands
 from discord.ui import Button, View
@@ -26,7 +27,8 @@ class aclient(discord.Client):
 client = aclient()
 tree = app_commands.CommandTree(client)
 
-quiz_leaderboard = {} # TODO: 봇이 재시작하면 리더보드가 초기화되는데, 이를 방지하는 작업 필요
+quiz_leaderboard = {}  # TODO: 봇이 재시작하면 리더보드가 초기화되는데, 이를 방지하는 작업 필요
+
 
 @tree.command(
     name="quiz",
@@ -85,7 +87,7 @@ async def self(interaction: discord.Interaction):
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     async def correct_answer_button_callback(interaction):
-        
+
         if str(interaction.user) in quiz_leaderboard[quiz_id]:
             embed = discord.Embed(
                 title="🚫",
@@ -101,7 +103,7 @@ async def self(interaction: discord.Interaction):
             return
 
         quiz_leaderboard[quiz_id].append(str(interaction.user))
-        
+
         embed = discord.Embed(
             title="⭕",
             description="You answered correct!\n\nUse `/quiz` to start a new quiz.",
@@ -118,12 +120,17 @@ async def self(interaction: discord.Interaction):
             rank = 1
             description = ""
             for user in quiz_leaderboard[quiz_id]:
-                if rank == 11: break
+                if rank == 11:
+                    break
 
-                if rank == 1: description += "🥇 " + user + "\n"
-                elif rank == 2: description += "🥈 " + user + "\n"
-                elif rank == 3: description += "🥉 " + user + "\n"
-                else: description += "`" + str(rank) + " ` " + user + "\n"
+                if rank == 1:
+                    description += "🥇 " + user + "\n"
+                elif rank == 2:
+                    description += "🥈 " + user + "\n"
+                elif rank == 3:
+                    description += "🥉 " + user + "\n"
+                else:
+                    description += "`" + str(rank) + " ` " + user + "\n"
                 rank += 1
 
             embed = discord.Embed(
@@ -133,7 +140,7 @@ async def self(interaction: discord.Interaction):
             )
 
             await interaction.response.send_message(embed=embed, ephemeral=True)
-            
+
         button.callback = button_callback
         view = View()
         view.add_item(button)
@@ -150,5 +157,6 @@ async def self(interaction: discord.Interaction):
 
     await interaction.response.send_message(answer_emoji)
     await interaction.channel.send(embed=embed, view=view)
+
 
 client.run(os.environ.get("TOKEN"))

--- a/src/bot.py
+++ b/src/bot.py
@@ -26,7 +26,7 @@ class aclient(discord.Client):
 client = aclient()
 tree = app_commands.CommandTree(client)
 
-quiz_leaderboard = {} # TODO: 봇이 재시작하면 리더보드가 초기화되는데, 
+quiz_leaderboard = {} # TODO: 봇이 재시작하면 리더보드가 초기화되는데, 이를 방지하는 작업 필요
 
 @tree.command(
     name="quiz",

--- a/src/bot.py
+++ b/src/bot.py
@@ -26,7 +26,7 @@ class aclient(discord.Client):
 client = aclient()
 tree = app_commands.CommandTree(client)
 
-quiz_leaderboard = {}
+quiz_leaderboard = {} # TODO: 봇이 재시작하면 리더보드가 초기화되는데, 
 
 @tree.command(
     name="quiz",


### PR DESCRIPTION
정답을 맞추거나, 오답을 맞출 때 나타나는 메세지들이 private message로 해당 유저에게만 보이게 변경.
맞춘 경우, leaderboard button이 하단에 나타남. 해당 버튼을 누를 시, 해당 퀴즈를 빨리 푼 순서대로 Top 10 리더보드를 private message로 볼 수 있음

처음에 눌렀을 때는 제가 제일 빨리 풀어 저만 표시되지만, 희원님이 정답을 맞춘 이후에 리더보드 버튼을 눌렀을 경우, 사진과 같이 갱신된 리더보드 모습을 확인 가능
<img width="419" alt="스크린샷 2022-08-25 18 18 13" src="https://user-images.githubusercontent.com/62659407/186626700-30ca2b2c-0024-45b9-a296-e806a54869b4.png">
